### PR TITLE
Update code for dealing with nargchk (avoid warning on R2016b)

### DIFF
--- a/@template/get.m
+++ b/@template/get.m
@@ -7,11 +7,24 @@ function varargout = get(tpl,action,varargin)
 %  Copyright (C) 2003 Guillaume Flandin <Guillaume@artefact.tk>
 %  $Revision: 1.0 $Date: 2003/05/05 22:19:51 $
 
-error(nargchk(2,3,nargin));
+%improvement for dealing with the obsolete nargchk function (removed in Matlab R2016c or R2017 and replaced by narginchk)
+useNarginchk=false;
+if exist('narginchk','builtin')
+	useNarginchk=true;
+end
+if useNarginchk
+	narginchk(2,3);
+else
+	error(nargchk(2,3,nargin));
+end
 
 switch lower(action)
 	case 'var'
-		error(nargchk(2,3,nargin));
+		if useNarginchk
+			narginchk(2,3);
+		else
+			error(nargchk(2,3,nargin));
+		end
 		if nargin == 2
 			varargout{1} = tpl.varvals;
 		elseif iscellstr(varargin{1})
@@ -31,7 +44,11 @@ switch lower(action)
 			varargout{1} = '';
 		end
 	case 'undefined'
-		error(nargchk(3,3,nargin));
+		if useNarginchk
+			narginchk(3,3);
+		else
+			error(nargchk(3,3,nargin));
+		end
 		tpl = loadtpl(tpl,varargin{1});
 		str = get(tpl,'var',varargin{1});
 		varargout{1} = {};

--- a/@template/parse.m
+++ b/@template/parse.m
@@ -11,7 +11,17 @@ function [tpl, str] = parse(tpl,target,handle,append)
 %  Copyright (C) 2003 Guillaume Flandin <Guillaume@artefact.tk>
 %  $Revision: 1.0 $Date: 2003/05/05 22:19:51 $
 
-error(nargchk(3,4,nargin));
+%improvement for dealing with the obsolete nargchk function (removed in Matlab R2016c or R2017 and replaced by narginchk)
+useNarginchk=false;
+if exist('narginchk','builtin')
+	useNarginchk=true;
+end
+if useNarginchk
+	narginchk(3,4);
+else
+	error(nargchk(3,4,nargin));
+end
+
 if nargin == 3
 	append = 0;
 end

--- a/@template/private/finish.m
+++ b/@template/private/finish.m
@@ -13,7 +13,16 @@ function str = finish(str,unknowns)
 %  Copyright (C) 2003 Guillaume Flandin <Guillaume@artefact.tk>
 %  $Revision: 1.0 $Date: 2003/05/05 22:19:51 $
 
-error(nargchk(2,2,nargin));
+%improvement for dealing with the obsolete nargchk function (removed in Matlab R2016c or R2017 and replaced by narginchk)
+useNarginchk=false;
+if exist('narginchk','builtin')
+	useNarginchk=true;
+end
+if useNarginchk
+	narginchk(2,2);
+else
+	error(nargchk(2,2,nargin));
+end
 
 switch lower(unknowns)
 	case 'keep'

--- a/@template/set.m
+++ b/@template/set.m
@@ -10,25 +10,46 @@ function tpl = set(tpl,action,varargin)
 %  Copyright (C) 2003 Guillaume Flandin <Guillaume@artefact.tk>
 %  $Revision: 1.0 $Date: 2003/05/05 22:19:51 $
 
-error(nargchk(3,5,nargin));
+%improvement for dealing with the obsolete nargchk function (removed in Matlab R2016c or R2017 and replaced by narginchk)
+useNarginchk=false;
+if exist('narginchk','builtin')
+	useNarginchk=true;
+end
+if useNarginchk
+	narginchk(3,5);
+else
+	error(nargchk(3,5,nargin));
+end
 
 switch lower(action)
 	case 'root'
-		error(nargchk(3,3,nargin));
+		if useNarginchk
+			narginchk(3,3);
+		else
+			error(nargchk(3,3,nargin));
+		end
 		if exist(varargin{1},'dir')
 			tpl.root = varargin{1};
 		else
 			error('[Template] No such directory.');
 		end
 	case 'unknowns'
-		error(nargchk(3,3,nargin));
+		if useNarginchk
+			narginchk(3,3);
+		else
+			error(nargchk(3,3,nargin));
+		end
 		if ismember(varargin{1},{'remove' 'comment' 'keep'})
 			tpl.unknowns = varargin{1};
 		else
 			error('[Template] Unknowns: ''remove'', ''comment'' or ''keep''.');
 		end
 	case 'file'
-		error(nargchk(4,4,nargin));
+		if useNarginchk
+			narginchk(4,4);
+		else
+			error(nargchk(4,4,nargin));
+		end
 		if iscellstr(varargin{1})
 			for i=1:length(varargin{1})
 				ind = find(ismember(tpl.handles,varargin{1}{i}));
@@ -53,7 +74,11 @@ switch lower(action)
 			error('[Template] Badly formed handles.');
 		end
 	case 'block'
-		error(nargchk(4,5,nargin));
+		if useNarginchk
+			narginchk(4,5);
+		else
+			error(nargchk(4,5,nargin));
+		end
 		tpl = loadtpl(tpl,varargin{1});
 		if nargin == 4
 			name = varargin{2};
@@ -85,7 +110,11 @@ switch lower(action)
 		tpl = set(tpl,'var',varargin{2},blk);
 		tpl = set(tpl,'var',varargin{1},str);
 	case 'var'
-		error(nargchk(3,4,nargin));
+		if useNarginchk
+			narginchk(3,4);
+		else
+			error(nargchk(3,4,nargin));
+		end
 		if iscellstr(varargin{1})
 			for i=1:length(varargin{1})
 				ind = find(ismember(tpl.varkeys,varargin{1}{i}));

--- a/@template/template.m
+++ b/@template/template.m
@@ -22,7 +22,16 @@ function tpl = template(root,unknowns)
 %  Copyright (C) 2003 Guillaume Flandin <Guillaume@artefact.tk>
 %  $Revision: 1.0 $Date: 2003/05/05 22:19:51 $
 
-error(nargchk(0,2,nargin));
+%improvement for dealing with the obsolete nargchk function (removed in Matlab R2016c or R2017 and replaced by narginchk)
+useNarginchk=false;
+if exist('narginchk','builtin')
+	useNarginchk=true;
+end
+if useNarginchk
+	narginchk(0,2);
+else
+	error(nargchk(0,2,nargin));
+end
 
 switch nargin
 	case 0

--- a/mdot.m
+++ b/mdot.m
@@ -18,7 +18,16 @@ function mdot(mmat, dotfile,f)
 %  Copyright (C) 2004 Guillaume Flandin <Guillaume@artefact.tk>
 %  $Revision: 1.1 $Date: 2004/05/05 17:14:09 $
 
-error(nargchk(2,3,nargin));
+%improvement for dealing with the obsolete nargchk function (removed in Matlab R2016c or R2017 and replaced by narginchk)
+useNarginchk=false;
+if exist('narginchk','builtin')
+	useNarginchk=true;
+end
+if useNarginchk
+	narginchk(2,3);
+else
+	error(nargchk(2,3,nargin));
+end
 
 if ischar(mmat)
 	load(mmat);

--- a/mwizard.m
+++ b/mwizard.m
@@ -31,7 +31,16 @@ function mwizard(file)
 %  guarantee is made whether and when they will be implemented.
 %  Send requests to Guillaume@artefact.tk
 
-error(nargchk(0,1,nargin));
+%improvement for dealing with the obsolete nargchk function (removed in Matlab R2016c or R2017 and replaced by narginchk)
+useNarginchk=false;
+if exist('narginchk','builtin')
+	useNarginchk=true;
+end
+if useNarginchk
+	narginchk(0,1);
+else
+	error(nargchk(0,1,nargin));
+end
 
 disp('This is a beta version of mwizard.');
 disp('Please use the online version m2html instead.');

--- a/mwizard2.m
+++ b/mwizard2.m
@@ -31,7 +31,16 @@ function mwizard(file)
 %  guarantee is made whether and when they will be implemented.
 %  Send requests to Guillaume@artefact.tk
 
-error(nargchk(0,1,nargin));
+%improvement for dealing with the obsolete nargchk function (removed in Matlab R2016c or R2017 and replaced by narginchk)
+useNarginchk=false;
+if exist('narginchk','builtin')
+	useNarginchk=true;
+end
+if useNarginchk
+	narginchk(0,1);
+else
+	error(nargchk(0,1,nargin));
+end
 
 disp('This is a beta version of mwizard.');
 disp('Please use the online version m2html instead.');

--- a/private/doxyread.m
+++ b/private/doxyread.m
@@ -31,7 +31,17 @@ function [statlist, docinfo] = doxyread(filename)
 
 %  See <http://www.doxygen.org/> for more details.
 
-error(nargchk(0,1,nargin));
+%improvement for dealing with the obsolete nargchk function (removed in Matlab R2016c or R2017 and replaced by narginchk)
+useNarginchk=false;
+if exist('narginchk','builtin')
+	useNarginchk=true;
+end
+if useNarginchk
+	narginchk(0,1);
+else
+	error(nargchk(0,1,nargin));
+end
+
 if nargin == 0,
 	filename = 'search.idx';
 end

--- a/private/doxysearch.m
+++ b/private/doxysearch.m
@@ -29,7 +29,17 @@ function result = doxysearch(query,filename)
 
 %  See <http://www.doxygen.org/> for more details.
 
-error(nargchk(1,2,nargin));
+%improvement for dealing with the obsolete nargchk function (removed in Matlab R2016c or R2017 and replaced by narginchk)
+useNarginchk=false;
+if exist('narginchk','builtin')
+	useNarginchk=true;
+end
+if useNarginchk
+	narginchk(1,2);
+else
+	error(nargchk(1,2,nargin));
+end
+
 if nargin == 1,
 	filename = 'search.idx';
 end

--- a/private/doxywrite.m
+++ b/private/doxywrite.m
@@ -32,7 +32,16 @@ function doxywrite(filename, kw, statinfo, docinfo)
 
 %  See <http://www.doxygen.org/> for more details.
 
-error(nargchk(4,4,nargin));
+%improvement for dealing with the obsolete nargchk function (removed in Matlab R2016c or R2017 and replaced by narginchk)
+useNarginchk=false;
+if exist('narginchk','builtin')
+	useNarginchk=true;
+end
+if useNarginchk
+	narginchk(4,4);
+else
+	error(nargchk(4,4,nargin));
+end
 
 %- Open the search index file
 [fid, errmsg] = fopen(filename,'w','ieee-be');

--- a/private/mfileparse.m
+++ b/private/mfileparse.m
@@ -18,7 +18,17 @@ function s = mfileparse(mfile, mdirs, names, options)
 %  Copyright (C) 2003 Guillaume Flandin <Guillaume@artefact.tk>
 %  $Revision: 1.0 $Date: 2003/29/04 17:33:43 $
 
-error(nargchk(3,4,nargin));
+%improvement for dealing with the obsolete nargchk function (removed in Matlab R2016c or R2017 and replaced by narginchk)
+useNarginchk=false;
+if exist('narginchk','builtin')
+	useNarginchk=true;
+end
+if useNarginchk
+	narginchk(3,4);
+else
+	error(nargchk(3,4,nargin));
+end
+
 if nargin == 3,
 	options = struct('verbose',1, 'globalHypertextLinks',0, 'todo',0);
 end

--- a/private/searchindex.m
+++ b/private/searchindex.m
@@ -13,7 +13,17 @@ function [s, freq] = searchindex(mfile, szmin)
 %  Copyright (C) 2003 Guillaume Flandin <Guillaume@artefact.tk>
 %  $Revision: 1.0 $Date: 2003/04/10 18:32:48 $
 
-error(nargchk(1,2,nargin));
+%improvement for dealing with the obsolete nargchk function (removed in Matlab R2016c or R2017 and replaced by narginchk)
+useNarginchk=false;
+if exist('narginchk','builtin')
+	useNarginchk=true;
+end
+if useNarginchk
+	narginchk(1,2);
+else
+	error(nargchk(1,2,nargin));
+end
+
 if nargin == 1, szmin = 2; end
 
 %- Delimiters used in strtok


### PR DESCRIPTION
Based on your repository, I have rewritten the section of the code using nargchk. This function will be obsolete in the next version of Matlab (probably on Matlab R2017a). Currently on R2016b, I have a lot of warnings. 
So if you want you can integrate it.
Regards